### PR TITLE
Fix  #14 - RSSHelperTest for iOS module fails

### DIFF
--- a/appstoresstats-ios/src/test/java/es/arcadiaconsulting/appstoresstats/ios/io/RSSHelperTest.java
+++ b/appstoresstats-ios/src/test/java/es/arcadiaconsulting/appstoresstats/ios/io/RSSHelperTest.java
@@ -8,7 +8,7 @@ import junit.framework.TestCase;
 public class RSSHelperTest extends TestCase{
 
 	public void testGetItunesURL(){
-		assertEquals("https://itunes.apple.com/es/app/iredes-2015/id604031647?mt=8&uo=2",RSSHelper.getItunesURL("604031647"));
+		assertEquals("https://itunes.apple.com/es/app/iredes-2016/id604031647?mt=8&uo=2",RSSHelper.getItunesURL("604031647"));
 		assertNull(RSSHelper.getItunesURL("invalid"));
 	}
 	


### PR DESCRIPTION
update App name for the test from iReded 2015 to iRedes 2016
